### PR TITLE
Pop the first few values from random during initialization

### DIFF
--- a/RandoMountAshita.lua
+++ b/RandoMountAshita.lua
@@ -10,6 +10,13 @@ MountList = require('mounts')
 function initialize_myMounts()
     
     math.randomseed(os.time())
+    math.random()
+    math.random()
+    math.random()
+    math.random()
+    math.random()
+    math.random()
+    math.random()
 
 end
 
@@ -31,7 +38,7 @@ function SummonRandomMount()
         local mountId = mounts[mountIndex]
 
         -- Summon the mount
-       local s = filter_name(MountList[mountId].en)
+        local s = filter_name(MountList[mountId].en)
         AshitaCore:GetChatManager():QueueCommand('/mount "'..s..'"', 1)
     else
         -- Notify the player that they have no mounts


### PR DESCRIPTION
Unfortunately, Lua's random number generator consistently gives the same sequence even with `seed(os.time)`. This change will pop those first few values off to get to the "more random" values.