### PR TITLE
Initalize table once and better seed logic

### DIFF
--- a/RandoMountAshita.lua
+++ b/RandoMountAshita.lua
@@ -16,15 +16,9 @@ function initialize_myMounts()
             table.insert(mounts, key_item.id)
         end
     end
-    
-    math.randomseed(os.time())
-    math.random()
-    math.random()
-    math.random()
-    math.random()
-    math.random()
-    math.random()
-    math.random()
+
+    local seed = tonumber(string.sub(string.reverse(tostring(os.time())),1,5))
+    math.randomseed(seed)
 end
 
 -- Define a function to pick a random mount and summon it

--- a/RandoMountAshita.lua
+++ b/RandoMountAshita.lua
@@ -7,7 +7,15 @@ _addon.version  = '1.0.0';
 
 MountList = require('mounts')
 
+mounts = {}
+
 function initialize_myMounts()
+    
+    for _, key_item in pairs(MountList) do
+        if AshitaCore:GetDataManager():GetPlayer():HasKeyItem(key_item.id) then
+            table.insert(mounts, key_item.id)
+        end
+    end
     
     math.randomseed(os.time())
     math.random()
@@ -17,20 +25,10 @@ function initialize_myMounts()
     math.random()
     math.random()
     math.random()
-
 end
 
 -- Define a function to pick a random mount and summon it
 function SummonRandomMount()
-    -- Initialize an empty table to store the player's mounts
-    local mounts = {}
-
-    for _, key_item in pairs(MountList) do
-        if AshitaCore:GetDataManager():GetPlayer():HasKeyItem(key_item.id) then
-            table.insert(mounts, key_item.id)
-        end
-    end
-
     -- Check if the player has any mounts
     if (#mounts > 0) then
         -- Select a random mount from the table


### PR DESCRIPTION
1. Moved the initialization of player's mounts to occur only once on loading the addon
2. Changed the random seed logic to produce a different sequence every time